### PR TITLE
[issues/24] githubactions導入

### DIFF
--- a/.github/workflows/cloudflare-development.yaml
+++ b/.github/workflows/cloudflare-development.yaml
@@ -1,0 +1,76 @@
+on:
+  pull_request: []
+  push:
+    branches:
+      - main
+      - 'issues/**'
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      deployments: write
+      statuses: write
+
+    name: Publish to Cloudflare Pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Install dependencies
+        run: pnpm i
+      - name: Build
+        run: npm run pages:build
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy .vercel/output/static --project-name=disaster-platform-dev
+      - name: Add publish URL as commit status
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const sha = context.payload.pull_request?.head.sha ?? context.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              context: 'Cloudflare Pages',
+              description: 'Cloudflare Pages deployment',
+              state: 'success',
+              sha,
+              target_url: "${{ steps.deploy.outputs.deployment-url }}",
+            });
+      - uses: chrnorm/deployment-action@v2
+        name: Create GitHub deployment
+        id: deployment
+        with:
+          token: '${{ github.token }}'
+          environment-url: "${{ steps.deploy.outputs.deployment-url }}"
+          environment: preview
+
+      - name: Update deployment status (success)
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ github.token }}'
+          environment-url: "${{ steps.deploy.outputs.deployment-url }}"
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status (failure)
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ github.token }}'
+          environment-url: "${{ steps.deploy.outputs.deployment-url }}"
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}


### PR DESCRIPTION
close #24 .

### 概要

- github Actionsを導入し、PR時にcloudflareにdeployを掛ける仕様に変更
- github Actionsによるデプロイをもとに、
自分のPRによってビルドした先の環境がどうなっているかを確認できるようになった。
- これにより、不慮の事故(mergeミス)がなくなる。